### PR TITLE
pT-sorting fixed. Be careful with `SortPt()`

### DIFF
--- a/AnaCodes/prachu/BasicEvtSelection/AnaScript.C
+++ b/AnaCodes/prachu/BasicEvtSelection/AnaScript.C
@@ -164,9 +164,7 @@ Bool_t AnaScript::Process(Long64_t entry)
 
       if(_data==0){
 	createGenLightLeptons();
-	SortPt(genMuon);
-	SortPt(genElectron);
-	SortPt(genLightLepton);
+        SortGenObjects();
 	//Make gen-level plots here.
       }
 
@@ -191,13 +189,7 @@ Bool_t AnaScript::Process(Long64_t entry)
       createTaus();
       createJets();
 
-      SortPt(Muon);
-      SortPt(Electron);
-      SortPt(LightLepton);
-      SortPt(Photon);
-      SortPt(Tau);
-      SortPt(Jet);
-      SortPt(bJet);
+      SortRecoObjects();
 
       //Basic object-level plots:
       //ELectrons

--- a/AnaCodes/prachu/BasicEvtSelection/AnaScript.h
+++ b/AnaCodes/prachu/BasicEvtSelection/AnaScript.h
@@ -442,6 +442,9 @@ public :
   void createTaus();
   void createJets();
   void createGenLightLeptons();
+  void SortRecoObjects();
+  void SortGenObjects();
+  void SortVLL();
   void EventSelection();
 
   //For specific studies:

--- a/AnaCodes/prachu/Skimmer/AnaScript.C
+++ b/AnaCodes/prachu/Skimmer/AnaScript.C
@@ -151,9 +151,7 @@ Bool_t AnaScript::Process(Long64_t entry)
       /*
       if(_data==0){
 	createGenLightLeptons();
-	SortPt(genMuon);
-	SortPt(genElectron);
-	SortPt(genLightLepton);
+	SortGenObjects();
 	//Make gen-level plots here.
 	}*/
 
@@ -178,13 +176,7 @@ Bool_t AnaScript::Process(Long64_t entry)
       createTaus();
       createJets();
 
-      SortPt(Muon);
-      SortPt(Electron);
-      SortPt(LightLepton);
-      SortPt(Photon);
-      SortPt(Tau);
-      SortPt(Jet);
-      SortPt(bJet);
+      SortRecoObjects();
 
       /*
       //Basic object-level plots:

--- a/AnaCodes/prachu/Skimmer/AnaScript.h
+++ b/AnaCodes/prachu/Skimmer/AnaScript.h
@@ -442,6 +442,9 @@ public :
   void createTaus();
   void createJets();
   void createGenLightLeptons();
+  void SortRecoObjects();
+  void SortGenObjects();
+  void SortVLL();
   void EventSelection();
   TString ParticleName(int pdgid);
 

--- a/AnaCodes/prachu/TreeMaker/AnaScript.C
+++ b/AnaCodes/prachu/TreeMaker/AnaScript.C
@@ -172,6 +172,8 @@ Bool_t AnaScript::Process(Long64_t entry)
 	SortPt(genMuon);
 	SortPt(genElectron);
 	SortPt(genLightLepton);
+
+	SortGenObjects();
 	//Make gen-level plots here.
       }
 
@@ -196,13 +198,7 @@ Bool_t AnaScript::Process(Long64_t entry)
       createTaus();
       createJets();
 
-      SortPt(Muon);
-      SortPt(Electron);
-      SortPt(LightLepton);
-      SortPt(Photon);
-      SortPt(Tau);
-      SortPt(Jet);
-      SortPt(bJet);
+      SortRecoObjects();
 
       /*
       //Basic object-level plots:

--- a/AnaCodes/prachu/TreeMaker/AnaScript.h
+++ b/AnaCodes/prachu/TreeMaker/AnaScript.h
@@ -444,6 +444,9 @@ public :
   void createTaus();
   void createJets();
   void createGenLightLeptons();
+  void SortRecoObjects();
+  void SortGenObjects();
+  void SortVLL();
   void EventSelection();
 
   //For specific studies:
@@ -613,30 +616,33 @@ private:
 
   //The variables to be put in the root files are global.
   //They should be decalred here.
-  UInt_t  nlep;  //[0,20<,UInt5_t>]
-  UInt_t  njet;  //[0,20<,UInt5_t>]
-  UInt_t  nbjet;  //[0,20<,UInt5_t>]
-  Float_t lep0_pt;  //[0,1500<,Float32_t>]
-  Float_t lep0_eta;  //[-6,6<,Float32_t>]
-  Float_t lep0_phi;  //[-6,6<,Float32_t>]
-  Float_t lep0_mt;  //[0,1500<,Float32_t>]
-  Float_t lep1_pt;  //[0,1500<,Float32_t>]
-  Float_t lep1_eta;  //[-6,6<,Float32_t>]
-  Float_t lep1_phi;  //[-6,6<,Float32_t>]
-  Float_t lep1_mt;  //[0,1500<,Float32_t>]
-  Float_t ll_pt;  //[0,1500<,Float32_t>]
-  Float_t ll_mass;  //[0,1500<,Float32_t>]
-  Float_t ll_deta;  //[0,6<,Float32_t>]
-  Float_t ll_dphi;  //[0,6<,Float32_t>]
-  Float_t ll_dR;  //[0,6<,Float32_t>]
-  Float_t ptratio;  //[0,1<,Float32_t>]
-  Float_t HT;  //[0,1500<,Float32_t>]
-  Float_t ST;  //[0,1500<,Float32_t>]
-  Float_t STfrac;  //[0,1<,Float32_t>]
-  Float_t dphi_metlep0;  //[0,6<,Float32_t>]
-  Float_t dphi_metlep1;  //[0,6<,Float32_t>]
-  Float_t dphi_metlep_max;  //[0,6<,Float32_t>]
-  Float_t dphi_metlep_min;  //[0,6<,Float32_t>]  
+  UInt_t  nlep;
+  UInt_t  njet;
+  UInt_t  nbjet;
+  Float_t lep0_pt;
+  Float_t lep0_eta;
+  Float_t lep0_phi;
+  Float_t lep0_mt;
+  Float_t lep1_pt;
+  Float_t lep1_eta;
+  Float_t lep1_phi;
+  Float_t lep1_mt;
+  Float_t dilep_pt;
+  Float_t dilep_eta;
+  Float_t dilep_phi;
+  Float_t dilep_mass;
+  Float_t dilep_mt;
+  Float_t ll_deta;
+  Float_t ll_dphi;
+  Float_t ll_dR;
+  Float_t ll_ptratio;
+  Float_t HT;
+  Float_t ST;
+  Float_t STfrac;
+  Float_t dphi_metlep0;
+  Float_t dphi_metlep1;
+  Float_t dphi_metlep_max;
+  Float_t dphi_metlep_min;
 
   ClassDef(AnaScript,0);
 

--- a/AnaCodes/prachu/TreeMaker/TreeMakerHelper.h
+++ b/AnaCodes/prachu/TreeMaker/TreeMakerHelper.h
@@ -1,29 +1,33 @@
 void AnaScript::InitializeBranches(TTree *tree){
-  tree->Branch("nlep",     &nlep);
-  tree->Branch("njet",     &njet);
-  tree->Branch("nbjet",    &nbjet);
-  tree->Branch("metpt",    &metpt);
-  tree->Branch("metphi",   &metphi);
-  tree->Branch("lep0_pt",  &lep0_pt);
-  tree->Branch("lep0_eta", &lep0_eta);
-  tree->Branch("lep0_phi", &lep0_phi);
-  tree->Branch("lep0_mt",  &lep0_mt);
-  tree->Branch("lep1_pt",  &lep1_pt);
-  tree->Branch("lep1_eta", &lep1_eta);
-  tree->Branch("lep1_phi", &lep1_phi);
-  tree->Branch("lep1_mt",  &lep1_mt);
-  tree->Branch("ll_pt",    &ll_pt);
-  tree->Branch("ll_mass",  &ll_mass);
-  tree->Branch("ll_deta",  &ll_deta);
-  tree->Branch("ll_dphi",  &ll_dphi);
-  tree->Branch("ll_dR",    &ll_dR);
-  tree->Branch("HT",       &HT);
-  tree->Branch("ST",       &ST);
-  tree->Branch("STfrac",   &STfrac);
-  tree->Branch("dphi_metlep0",      &dphi_metlep0);
-  tree->Branch("dphi_metlep1",      &dphi_metlep1);
-  tree->Branch("dphi_metlep_max",   &dphi_metlep_max);
-  tree->Branch("dphi_metlep_min",   &dphi_metlep_min);
+  tree->Branch("nlep",      &nlep);
+  tree->Branch("njet",      &njet);
+  tree->Branch("nbjet",     &nbjet);
+  tree->Branch("metpt",     &metpt);
+  tree->Branch("metphi",    &metphi);
+  tree->Branch("lep0_pt",   &lep0_pt);
+  tree->Branch("lep0_eta",  &lep0_eta);
+  tree->Branch("lep0_phi",  &lep0_phi);
+  tree->Branch("lep0_mt",   &lep0_mt);
+  tree->Branch("lep1_pt",   &lep1_pt);
+  tree->Branch("lep1_eta",  &lep1_eta);
+  tree->Branch("lep1_phi",  &lep1_phi);
+  tree->Branch("lep1_mt",   &lep1_mt);
+  tree->Branch("dilep_pt",  &dilep_pt);
+  tree->Branch("dilep_eta", &dilep_eta);
+  tree->Branch("dilep_phi", &dilep_phi);
+  tree->Branch("dilep_mass",&dilep_mass);
+  tree->Branch("dilep_mt",  &dilep_mt);
+  tree->Branch("ll_deta",   &ll_deta);
+  tree->Branch("ll_dphi",   &ll_dphi);
+  tree->Branch("ll_dR",     &ll_dR);
+  tree->Branch("ll_ptratio",&ll_ptratio);
+  tree->Branch("HT",        &HT);
+  tree->Branch("ST",        &ST);
+  tree->Branch("STfrac",    &STfrac);
+  tree->Branch("dphi_metlep0",    &dphi_metlep0);
+  tree->Branch("dphi_metlep1",    &dphi_metlep1);
+  tree->Branch("dphi_metlep_max", &dphi_metlep_max);
+  tree->Branch("dphi_metlep_min", &dphi_metlep_min);
 }
 
 void AnaScript::FillTree(TTree *tree){
@@ -59,17 +63,23 @@ void AnaScript::FillTree(TTree *tree){
 
     //Dilepton system:
     TLorentzVector dilep = LightLepton.at(0).v + LightLepton.at(1).v;
-    ll_pt   = (Float_t)dilep.Pt();
-    ll_mass = (Float_t)dilep.M();
-    ll_deta = (Float_t)fabs(LightLepton.at(0).v.Eta() - LightLepton.at(1).v.Eta());
-    ll_dphi = (Float_t)delta_phi(LightLepton.at(0).v.Phi(), LightLepton.at(1).v.Phi());
-    ll_dR   = (Float_t)LightLepton.at(0).v.DeltaR(LightLepton.at(1).v);
-    ptratio = (Float_t)LightLepton.at(1).v.Pt() / LightLepton.at(0).v.Pt();
+    dilep_pt   = (Float_t)dilep.Pt();
+    dilep_eta  = (Float_t)dilep.Eta();
+    dilep_phi  = (Float_t)dilep.Phi();
+    dilep_mass = (Float_t)dilep.M();
+    dilep_mt   = (Float_t)transv_mass(dilep.E(), dilep.Phi(), metpt, metphi);
+    ll_deta    = (Float_t)fabs(LightLepton.at(0).v.Eta() - LightLepton.at(1).v.Eta());
+    ll_dphi    = (Float_t)delta_phi(LightLepton.at(0).v.Phi(), LightLepton.at(1).v.Phi());
+    ll_dR      = (Float_t)LightLepton.at(0).v.DeltaR(LightLepton.at(1).v);
+    ll_ptratio = (Float_t)lep1_pt/lep0_pt;
+
+
+    if(lep0_pt < lep1_pt) cout<<"Sorting error!"<<endl;
 
     //Event level:
     HT=0; for(Int_t i=0; i<(Int_t)Jet.size(); i++) HT = HT + Jet.at(i).v.Pt();
-    ST = HT + ll_pt;
-    STfrac = 0; if(ST>0) STfrac = ll_pt/ST;
+    ST = HT + dilep_pt;
+    STfrac = 0; if(ST>0) STfrac = dilep_pt/ST;
     dphi_metlep0 = (Float_t)delta_phi(LightLepton.at(0).v.Phi(), metphi);
     dphi_metlep1 = (Float_t)delta_phi(LightLepton.at(1).v.Phi(), metphi);
     dphi_metlep_max = (Float_t)max(dphi_metlep0, dphi_metlep1);

--- a/Setup/CustomFunctions.h
+++ b/Setup/CustomFunctions.h
@@ -1,7 +1,69 @@
 void AnaScript::SortPt(vector<Particle> part){
-  for(int i=0; i<(int)part.size()-1; i++){
-    for(int j=i+1; j<(int)part.size(); j++){
-      if( part[i].v.Pt() < part[j].v.Pt() ) swap(part[i],part[j]); }}
+  //Note: This function is problematic.
+  //It fails at some instances (not all).
+  //Don't use it until it gets fixed.
+  for(int i=0; i<(int)part.size()-1; i++){//first one
+    for(int j=i+1; j<(int)part.size(); j++){//second one
+      if( part[i].v.Pt() < part[j].v.Pt() ) swap(part.at(i), part.at(j));
+    }
+  }
+}
+
+void AnaScript::SortRecoObjects(){
+  //Muons:
+  for(int i=0; i<(int)Muon.size()-1; i++){
+    for(int j=i+1; j<(int)Muon.size(); j++){
+      if(Muon[i].v.Pt() < Muon[j].v.Pt() ) swap(Muon.at(i), Muon.at(j));}}  
+  //Electrons:
+  for(int i=0; i<(int)Electron.size()-1; i++){
+    for(int j=i+1; j<(int)Electron.size(); j++){
+      if(Electron[i].v.Pt() < Electron[j].v.Pt() ) swap(Electron.at(i), Electron.at(j));}}
+  //LightLeptons
+  for(int i=0; i<(int)LightLepton.size()-1; i++){
+    for(int j=i+1; j<(int)LightLepton.size(); j++){
+      if(LightLepton[i].v.Pt() < LightLepton[j].v.Pt() ) swap(LightLepton.at(i), LightLepton.at(j));}}
+  //Photons:
+  for(int i=0; i<(int)Photon.size()-1; i++){
+    for(int j=i+1; j<(int)Photon.size(); j++){
+      if(Photon[i].v.Pt() < Photon[j].v.Pt() ) swap(Photon.at(i), Photon.at(j));}}
+  //Jets:
+  for(int i=0; i<(int)Jet.size()-1; i++){
+    for(int j=i+1; j<(int)Jet.size(); j++){
+      if(Jet[i].v.Pt() < Jet[j].v.Pt() ) swap(Jet.at(i), Jet.at(j));}}
+  //bJets:
+  for(int i=0; i<(int)bJet.size()-1; i++){
+    for(int j=i+1; j<(int)bJet.size(); j++){
+      if(bJet[i].v.Pt() < bJet[j].v.Pt() ) swap(bJet.at(i), bJet.at(j));}}
+  //LooseLeptons:
+  for(int i=0; i<(int)LooseLepton.size()-1; i++){
+    for(int j=i+1; j<(int)LooseLepton.size(); j++){
+      if(LooseLepton[i].v.Pt() < LooseLepton[j].v.Pt() ) swap(LooseLepton.at(i), LooseLepton.at(j));}}
+}
+
+void AnaScript::SortGenObjects(){
+  //genMuons:
+  for(int i=0; i<(int)genMuon.size()-1; i++){
+    for(int j=i+1; j<(int)genMuon.size(); j++){
+      if(genMuon[i].v.Pt() < genMuon[j].v.Pt() ) swap(genMuon.at(i), genMuon.at(j));}}
+  //genElectrons:
+  for(int i=0; i<(int)genElectron.size()-1; i++){
+    for(int j=i+1; j<(int)genElectron.size(); j++){
+      if(genElectron[i].v.Pt() < genElectron[j].v.Pt() ) swap(genElectron.at(i), genElectron.at(j));}}
+  //genLightLeptons:
+  for(int i=0; i<(int)genLightLepton.size()-1; i++){
+    for(int j=i+1; j<(int)genLightLepton.size(); j++){
+      if(genLightLepton[i].v.Pt() < genLightLepton[j].v.Pt() ) swap(genLightLepton.at(i), genLightLepton.at(j));}}
+}
+
+void AnaScript::SortVLL(){
+  //vllep:
+  for(int i=0; i<(int)vllep.size()-1; i++){
+    for(int j=i+1; j<(int)vllep.size(); j++){
+      if(vllep[i].v.Pt() < vllep[j].v.Pt() ) swap(vllep.at(i), vllep.at(j));}}
+  //vlnu:
+  for(int i=0; i<(int)vlnu.size()-1; i++){
+    for(int j=i+1; j<(int)vlnu.size(); j++){
+      if(vlnu[i].v.Pt() < vlnu[j].v.Pt() ) swap(vlnu.at(i), vlnu.at(j));}}
 }
 
 float AnaScript::delta_phi(float phi1, float phi2){

--- a/Setup/Studies/signal_plots.h
+++ b/Setup/Studies/signal_plots.h
@@ -87,8 +87,9 @@ void AnaScript::MakeSignalPlots(float wt){
     }
   }
 
-  SortPt(vllep);
-  SortPt(vlnu);
+  //SortPt(vllep);
+  //SortPt(vlnu);
+  SortVLL();
   
   //---------------------------------------------------
   //Counting daughters:


### PR DESCRIPTION
The `bool SortPt(vector<Particle>)` function is problematic. I haven't found the reason why it fails at some instances. I replaced it with regular bool functions that target individual `vector<Particle>` objects instead of taking them as arguments.